### PR TITLE
Enable the hardened runtime

### DIFF
--- a/MacDown.xcodeproj/project.pbxproj
+++ b/MacDown.xcodeproj/project.pbxproj
@@ -485,6 +485,8 @@
 		1FFEB32919737D6E00B2254F /* YAMLSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YAMLSerialization.h; sourceTree = "<group>"; };
 		1FFEB32A19737D6E00B2254F /* YAMLSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YAMLSerialization.m; sourceTree = "<group>"; };
 		1FFF301C1948A5320009AF24 /* MPStringLookupTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPStringLookupTests.m; sourceTree = "<group>"; };
+		21CF44B529B24D970039136F /* MacDown.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MacDown.entitlements; sourceTree = "<group>"; };
+		21CF44BA29B256990039136F /* macdown-cmd.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "macdown-cmd.entitlements"; sourceTree = "<group>"; };
 		263367245B2D78A42C2F19D7 /* libPods-macdown-cmd.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-macdown-cmd.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3028039D1FD84EAB0055B0DA /* contribute.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = contribute.md; path = Resources/contribute.md; sourceTree = "<group>"; };
 		39EFCAE04F60154F0C8C5469 /* Pods-MacDown.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MacDown.release.xcconfig"; path = "Pods/Target Support Files/Pods-MacDown/Pods-MacDown.release.xcconfig"; sourceTree = "<group>"; };
@@ -814,6 +816,7 @@
 		1FCDC9EB1944F89B00B1F966 /* MacDown */ = {
 			isa = PBXGroup;
 			children = (
+				21CF44B529B24D970039136F /* MacDown.entitlements */,
 				1F0D9D62194AC7CF008E1856 /* Utility */,
 				1F0D9D5D194AC7CF008E1856 /* Extension */,
 				1F396E6319B0EA17000D3EFC /* View */,
@@ -877,6 +880,7 @@
 		905EF1AA196164CA00FC3CE9 /* macdown-cmd */ = {
 			isa = PBXGroup;
 			children = (
+				21CF44BA29B256990039136F /* macdown-cmd.entitlements */,
 				1FCD711A1A20BE2F00C028B5 /* version.h */,
 				1F8858BA1A2D8D82008DC543 /* MPArgumentProcessor.h */,
 				1F8858BB1A2D8D82008DC543 /* MPArgumentProcessor.m */,
@@ -1756,9 +1760,11 @@
 			baseConfigurationReference = 1A198D1BA59D710201DD3BC8 /* Pods-MacDown.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = MacDown/MacDown.entitlements;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = M57TZFTAQ6;
+				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MacDown/Code/MacDown-Prefix.pch";
 				INFOPLIST_FILE = "MacDown/MacDown-Info.plist";
@@ -1776,9 +1782,11 @@
 			baseConfigurationReference = 39EFCAE04F60154F0C8C5469 /* Pods-MacDown.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = MacDown/MacDown.entitlements;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = M57TZFTAQ6;
+				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MacDown/Code/MacDown-Prefix.pch";
 				INFOPLIST_FILE = "MacDown/MacDown-Info.plist";
@@ -1859,6 +1867,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4DBAA63927A60EB2150642B3 /* Pods-macdown-cmd.debug.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "macdown-cmd/macdown-cmd.entitlements";
+				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1874,6 +1884,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7A8EA75FA95818275755F0B6 /* Pods-macdown-cmd.release.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "macdown-cmd/macdown-cmd.entitlements";
+				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
 				PRODUCT_NAME = macdown;

--- a/MacDown.xcodeproj/project.pbxproj
+++ b/MacDown.xcodeproj/project.pbxproj
@@ -1783,7 +1783,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = MacDown/MacDown.entitlements;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Developer ID Application: Lawrence Forooghian (M57TZFTAQ6)";
 				COMBINE_HIDPI_IMAGES = YES;
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = M57TZFTAQ6;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1885,6 +1885,7 @@
 			baseConfigurationReference = 7A8EA75FA95818275755F0B6 /* Pods-macdown-cmd.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "macdown-cmd/macdown-cmd.entitlements";
+				CODE_SIGN_IDENTITY = "Developer ID Application: Lawrence Forooghian (M57TZFTAQ6)";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";

--- a/MacDown/MacDown.entitlements
+++ b/MacDown/MacDown.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Podfile
+++ b/Podfile
@@ -14,7 +14,7 @@ target "MacDown" do
   pod 'LibYAML', '~> 0.1'
   pod 'M13OrderedDictionary', '~> 1.1'
   pod 'MASPreferences', '~> 1.3'
-  pod 'Sparkle', '~> 1.18', :inhibit_warnings => false
+  pod 'Sparkle', '~> 1.24', :inhibit_warnings => false
 
   # Locked on 0.4.x until we drop 10.8.
   pod 'PAPreferences', '~> 0.4'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - M13OrderedDictionary (1.1.0)
   - MASPreferences (1.3)
   - PAPreferences (0.5)
-  - Sparkle (1.18.1)
+  - Sparkle (1.24.0)
 
 DEPENDENCIES:
   - GBCli (~> 1.1)
@@ -20,7 +20,7 @@ DEPENDENCIES:
   - M13OrderedDictionary (~> 1.1)
   - MASPreferences (~> 1.3)
   - PAPreferences (~> 0.4)
-  - Sparkle (~> 1.18)
+  - Sparkle (~> 1.24)
 
 SPEC REPOS:
   https://github.com/MacDownApp/cocoapods-specs.git:
@@ -44,8 +44,8 @@ SPEC CHECKSUMS:
   M13OrderedDictionary: 6e157fe9c82aa6b3cd7198f5c5c30c7a6834c4a6
   MASPreferences: c08b8622dd17b47da87669e741efd7c92e970e8c
   PAPreferences: 9f0ffb1e67174a0df001af9d3320166ceb9ee6f5
-  Sparkle: 06ea33170007c5937ee54da481b4481af98fac79
+  Sparkle: 270cd27377bf04e9c128af06e3a22d0f572d6ee3
 
-PODFILE CHECKSUM: e9356b9a2ceafda7889ba385de6e9f2d8b06cba0
+PODFILE CHECKSUM: 8647c11f148b94186ec177db56595ff63603ca5a
 
 COCOAPODS: 1.11.3

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,5 +32,10 @@ lane :build_release do
     export_method: "developer-id",
     export_team_id: "M57TZFTAQ6",
     output_directory: "release",
+    export_options: {
+      provisioningProfiles: {
+        "com.forooghian.macdown" => "match Direct com.forooghian.macdown macos"
+      }
+    }
   )
 end

--- a/macdown-cmd/macdown-cmd.entitlements
+++ b/macdown-cmd/macdown-cmd.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>


### PR DESCRIPTION
This needs to be enabled in order to notarize an app (#12). I don’t know if we now require any additional entitlements; for now I will assume not and enable them if anything comes up whilst testing.